### PR TITLE
Implementing approximate F-14 AoA on speed handling

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -141,6 +141,7 @@ static FA18C: AirplaneInfo = AirplaneInfo {
         z: -7.237348,
     },
     glide_slope: 3.5,
+    plane_type: "FA18C",
 };
 
 static F14: AirplaneInfo = AirplaneInfo {
@@ -150,6 +151,7 @@ static F14: AirplaneInfo = AirplaneInfo {
         z: -6.563727,
     },
     glide_slope: 3.5,
+    plane_type: "F14",
 };
 
 static T45: AirplaneInfo = AirplaneInfo {
@@ -159,6 +161,7 @@ static T45: AirplaneInfo = AirplaneInfo {
         z: -4.782536,
     },
     glide_slope: 3.5,
+    plane_type: "T45",
 };
 
 #[derive(Debug)]
@@ -204,6 +207,8 @@ pub struct AirplaneInfo {
     pub hook: DVec3,
     /// The optimal glide slope in degrees.
     pub glide_slope: f64,
+    /// The type of aircraft used to select proper on speed color.
+    pub plane_type: &'static str,
 }
 
 impl AirplaneInfo {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -354,36 +354,19 @@ fn text_style() -> TextStyle<'static> {
 
 fn aoa_color(aoa: f64, plane_type: &'static str) -> RGBColor {
     if plane_type == "F14" {
-        // https://www.heatblur.se/F-14Manual/cockpit.html?highlight=aoa#approach-indexer
-        if aoa <= 14.0 {
+        // https://www.heatblur.se/F-14Manual/cockpit.html?highlight=aoa#approach-indexer\
+        // aoa degrees for tomcat calculated by degrees=((units/1.0989) - 3.01) from units in manual based off conversation found here:
+        // https://forum.dcs.world/topic/228893-aoa-units-to-degrees-conversion/#:~:text=Which%20makes%20around%201%20unit%3D1%2C67%20degrees.
+        if aoa <= 9.7 {
             // fast
             THEME_AOA_FAST
-        } else if aoa <= 14.5 {
+        } else if aoa <= 10.2 {
             // slightly fast
             THEME_AOA_SLIGHTLY_FAST
-        } else if aoa < 15.5 {
+        } else if aoa < 11.0 {
             // on speed
             THEME_AOA_ON_SPEED
-        } else if aoa < 16.0 {
-            // slightly slow
-            THEME_AOA_SLIGHTLY_SLOW
-        } else {
-            // slow
-            THEME_AOA_SLOW
-        }
-    } else if plane_type == "T45" {
-        // http://www.fsx-info.de/dateien/t45-manual.pdf
-        // page 44
-        if aoa <= 16.0 {
-            // fast
-            THEME_AOA_FAST
-        } else if aoa <= 16.5 {
-            // slightly fast
-            THEME_AOA_SLIGHTLY_FAST
-        } else if aoa < 17.0 {
-            // on speed
-            THEME_AOA_ON_SPEED
-        } else if aoa < 17.5 {
+        } else if aoa < 11.6 {
             // slightly slow
             THEME_AOA_SLIGHTLY_SLOW
         } else {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -191,7 +191,7 @@ pub fn draw_top_view(
     let mut points = Vec::new();
     let mut color = THEME_AOA_ON_SPEED;
     for datum in track_in_nm {
-        let next_color = aoa_color(datum.aoa);
+        let next_color = aoa_color(datum.aoa, track.plane_type);
         let point = (datum.x, datum.y);
 
         if points.is_empty() {
@@ -315,7 +315,7 @@ pub fn draw_side_view(
     let mut points = Vec::new();
     let mut color = THEME_AOA_ON_SPEED;
     for datum in track_descent {
-        let next_color = aoa_color(datum.aoa);
+        let next_color = aoa_color(datum.aoa, track.plane_type);
 
         let point = (datum.x, datum.alt);
 
@@ -352,23 +352,63 @@ fn text_style() -> TextStyle<'static> {
     TextStyle::from(("sans-serif", 20).into_font()).color(&THEME_FG)
 }
 
-fn aoa_color(aoa: f64) -> RGBColor {
-    // https://forums.vrsimulations.com/support/index.php/Navigation_Tutorial_Flight#Angle_of_Attack_Bracket
-    if aoa <= 6.9 {
-        // fast
-        THEME_AOA_FAST
-    } else if aoa <= 7.4 {
-        // slightly fast
-        THEME_AOA_SLIGHTLY_FAST
-    } else if aoa < 8.8 {
-        // on speed
-        THEME_AOA_ON_SPEED
-    } else if aoa < 9.3 {
-        // slightly slow
-        THEME_AOA_SLIGHTLY_SLOW
+fn aoa_color(aoa: f64, plane_type: &'static str) -> RGBColor {
+    if plane_type == "F14" {
+        // https://www.heatblur.se/F-14Manual/cockpit.html?highlight=aoa#approach-indexer
+        if aoa <= 14.0 {
+            // fast
+            THEME_AOA_FAST
+        } else if aoa <= 14.5 {
+            // slightly fast
+            THEME_AOA_SLIGHTLY_FAST
+        } else if aoa < 15.5 {
+            // on speed
+            THEME_AOA_ON_SPEED
+        } else if aoa < 16.0 {
+            // slightly slow
+            THEME_AOA_SLIGHTLY_SLOW
+        } else {
+            // slow
+            THEME_AOA_SLOW
+        }
+    } else if plane_type == "T45" {
+        // http://www.fsx-info.de/dateien/t45-manual.pdf
+        // page 44
+        if aoa <= 16.0 {
+            // fast
+            THEME_AOA_FAST
+        } else if aoa <= 16.5 {
+            // slightly fast
+            THEME_AOA_SLIGHTLY_FAST
+        } else if aoa < 17.0 {
+            // on speed
+            THEME_AOA_ON_SPEED
+        } else if aoa < 17.5 {
+            // slightly slow
+            THEME_AOA_SLIGHTLY_SLOW
+        } else {
+            // slow
+            THEME_AOA_SLOW
+        }
     } else {
-        // slow
-        THEME_AOA_SLOW
+        // default to FA18C
+        // https://forums.vrsimulations.com/support/index.php/Navigation_Tutorial_Flight#Angle_of_Attack_Bracket
+        if aoa <= 6.9 {
+            // fast
+            THEME_AOA_FAST
+        } else if aoa <= 7.4 {
+            // slightly fast
+            THEME_AOA_SLIGHTLY_FAST
+        } else if aoa < 8.8 {
+            // on speed
+            THEME_AOA_ON_SPEED
+        } else if aoa < 9.3 {
+            // slightly slow
+            THEME_AOA_SLIGHTLY_SLOW
+        } else {
+            // slow
+            THEME_AOA_SLOW
+        }
     }
 }
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -354,7 +354,7 @@ fn text_style() -> TextStyle<'static> {
 
 fn aoa_color(aoa: f64, plane_type: &'static str) -> RGBColor {
     if plane_type == "F14" {
-        // https://www.heatblur.se/F-14Manual/cockpit.html?highlight=aoa#approach-indexer\
+        // https://www.heatblur.se/F-14Manual/cockpit.html?highlight=aoa#approach-indexer
         // aoa degrees for tomcat calculated by degrees=((units/1.0989) - 3.01) from units in manual based off conversation found here:
         // https://forum.dcs.world/topic/228893-aoa-units-to-degrees-conversion/#:~:text=Which%20makes%20around%201%20unit%3D1%2C67%20degrees.
         if aoa <= 9.7 {
@@ -363,7 +363,7 @@ fn aoa_color(aoa: f64, plane_type: &'static str) -> RGBColor {
         } else if aoa <= 10.2 {
             // slightly fast
             THEME_AOA_SLIGHTLY_FAST
-        } else if aoa < 11.0 {
+        } else if aoa < 11.1 {
             // on speed
             THEME_AOA_ON_SPEED
         } else if aoa < 11.6 {

--- a/src/track.rs
+++ b/src/track.rs
@@ -41,6 +41,7 @@ pub struct TrackResult {
     pub grading: Grading,
     pub dcs_grading: Option<String>,
     pub datums: Vec<Datum>,
+    pub plane_type: &'static str,
 }
 
 impl Track {
@@ -161,6 +162,7 @@ impl Track {
             grading,
             dcs_grading: self.dcs_grading,
             datums: self.datums,
+            plane_type: self.plane_info.plane_type,
         }
     }
 


### PR DESCRIPTION
This implements aircraft specific AoA color handling for the F-14.  It is likely not perfect, but as close as I could get using the AoA Units from the Heatblur Manual and converting to degrees using the formula degrees=((units/1.0989) - 3.01) based on math found here: https://forum.dcs.world/topic/228893-aoa-units-to-degrees-conversion/#:~:text=Which%20makes%20around%201%20unit%3D1%2C67%20degrees.

Through testing it has shown to be fairly accurate, and at the very least gives more info than using the hornet data. 